### PR TITLE
Check for conflicting FASM features

### DIFF
--- a/qlf_fasm/qlf_fasm.py
+++ b/qlf_fasm/qlf_fasm.py
@@ -576,6 +576,7 @@ def main():
 
     except QlfFasmException as ex:
         logging.critical("ERROR: " + str(ex))
+        exit(-1)
 
 # =============================================================================
 

--- a/tests/test_bitstream_roundtrip.py
+++ b/tests/test_bitstream_roundtrip.py
@@ -5,6 +5,8 @@ import tempfile
 import subprocess
 import tarfile
 
+import pytest
+
 # =============================================================================
 
 
@@ -15,9 +17,7 @@ def bitstream_roundtrip(bitstream_file, bitstream_format):
 
     basedir = os.path.dirname(__file__)
     qlf_fasm = "python3 -m qlf_fasm"
-
     db_root = os.environ.get("QLF_FASM_DB_ROOT", None)
-    assert db_root is not None, "QLF_FASM_DB_ROOT env. variable not set"
 
     with tempfile.TemporaryDirectory() as tempdir:
 
@@ -70,8 +70,10 @@ def bitstream_roundtrip(bitstream_file, bitstream_format):
         assert fasm_lines1 == fasm_lines2
 
 
+@pytest.mark.skipif("QLF_FASM_DB_ROOT" not in os.environ, reason="QLF_FASM_DB_ROOT not set")
 def test_txt_bitstream_roundtrip():
     bitstream_roundtrip("qlf_k4n8-counter.bit.tar.gz", "txt")
 
+@pytest.mark.skipif("QLF_FASM_DB_ROOT" not in os.environ, reason="QLF_FASM_DB_ROOT not set")
 def test_4byte_bitstream_roundtrip():
     bitstream_roundtrip("qlf_k4n8-and.hex.tar.gz", "4byte")

--- a/tests/test_bitstream_roundtrip.py
+++ b/tests/test_bitstream_roundtrip.py
@@ -16,6 +16,9 @@ def bitstream_roundtrip(bitstream_file, bitstream_format):
     basedir = os.path.dirname(__file__)
     qlf_fasm = "python3 -m qlf_fasm"
 
+    db_root = os.environ.get("QLF_FASM_DB_ROOT", None)
+    assert db_root is not None, "QLF_FASM_DB_ROOT env. variable not set"
+
     with tempfile.TemporaryDirectory() as tempdir:
 
         # Unpack the bitstream
@@ -24,13 +27,12 @@ def bitstream_roundtrip(bitstream_file, bitstream_format):
         tar.extractall(path=tempdir)
 
         # Disassemble the bitstream
-        database = os.path.join(basedir, "..", "qlf_fasm", "database", "qlf_k4n8")
         bitstream1 = os.path.join(tempdir, os.path.basename(bitstream).replace(".tar.gz", ""))
         fasm1 = os.path.join(tempdir, "fasm1.fasm")
 
         args = "{} --db-root {} {} {} -d -f {}".format(
             qlf_fasm,
-            database,
+            db_root,
             bitstream1,
             fasm1,
             bitstream_format
@@ -41,7 +43,7 @@ def bitstream_roundtrip(bitstream_file, bitstream_format):
         bitstream2 = os.path.join(tempdir, "bitstream2.bit")
         args = "{} --db-root {} {} {} -a -f {}".format(
             qlf_fasm,
-            database,
+            db_root,
             fasm1,
             bitstream2,
             bitstream_format
@@ -52,7 +54,7 @@ def bitstream_roundtrip(bitstream_file, bitstream_format):
         fasm2 = os.path.join(tempdir, "fasm2.fasm")
         args = "{} --db-root {} {} {} -d -f {}".format(
             qlf_fasm,
-            database,
+            db_root,
             bitstream2,
             fasm2,
             bitstream_format


### PR DESCRIPTION
This PR adds a check for possible FASM feature conflicts like:
```
FEATURE=1'b1
FEATURE=1'b0
```
It also improves error reporting

IMPORTANT. This PR will make qlf_fasm fail on the current arch. The other PR that fixes FASM feature injection needs to be merged and the architecture re-generated: https://github.com/QuickLogic-Corp/OpenFPGA-QLF_K4N8/pull/185